### PR TITLE
fixed a bug that avoids to use types from other packages

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -243,6 +243,7 @@ func isAlphaNumeric(r rune) bool {
 func wordify(s string, exported bool) string {
 	s = strings.TrimRight(s, "{}")
 	s = strings.TrimLeft(s, "*&")
+	s = strings.Replace(s, ".", "", -1)
 	if !exported {
 		return s
 	}

--- a/parse/parse_int_test.go
+++ b/parse/parse_int_test.go
@@ -26,6 +26,8 @@ func TestWordify(t *testing.T) {
 		"*MyType":     "MyType",
 		"*myType":     "MyType",
 		"interface{}": "Interface",
+		"pack.type":   "Packtype",
+		"*pack.type":  "Packtype",
 	} {
 		assert.Equal(t, wordified, wordify(word, true))
 	}


### PR DESCRIPTION
if the dot is not removed from the name, the generated code does not compile because dots are not allowed in a simple identifier.