### PR TITLE
Allow to use go:generate $GOPATH/bin/genny

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -38,6 +38,7 @@ var (
 )
 var unwantedLinePrefixes = [][]byte{
 	[]byte("//go:generate genny "),
+	[]byte("//go:generate $GOPATH/bin/genny "),
 }
 
 func generateSpecific(filename string, in io.ReadSeeker, typeSet map[string]string) ([]byte, error) {


### PR DESCRIPTION
This is frequently used go:generate prefix.