### PR TITLE
use text/scanner to tokenize input documents for better handling of complex types

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"text/scanner"
 	"unicode"
 
 	"golang.org/x/tools/imports"
@@ -80,69 +81,60 @@ func generateSpecific(filename string, in io.ReadSeeker, typeSet map[string]stri
 	in.Seek(0, os.SEEK_SET)
 
 	var buf bytes.Buffer
+	var lineBuf bytes.Buffer
 
-	comment := ""
-	scanner := bufio.NewScanner(in)
-	for scanner.Scan() {
+	var s scanner.Scanner
+	s.Init(in)
+	s.Filename = filename
+	s.Mode = scanner.ScanIdents
+	// tokenize all whitespace as well so we can recreate the input stream
+	s.Whitespace = 0
+	// scan through all the tokens with special handling for Identifier tokens
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		word := s.TokenText()
+		if tok == '\n' {
+			line := lineBuf.String()
+			if strings.Contains(line, genericType) || strings.Contains(line, genericNumber) {
+				lineBuf.Reset()
+				continue
+			}
+			buf.Write(lineBuf.Bytes())
+			lineBuf.Reset()
+		}
 
-		l := scanner.Text()
-
-		// does this line contain generic.Type?
-		if strings.Contains(l, genericType) || strings.Contains(l, genericNumber) {
-			comment = ""
+		// only process indentifier tokens
+		if tok != scanner.Ident {
+			lineBuf.WriteString(word)
 			continue
 		}
 
 		for t, specificType := range typeSet {
 
 			// does the line contain our type
-			if strings.Contains(l, t) {
+			if strings.Contains(word, t) {
+				i := 0
+				for {
+					i = strings.Index(word[i:], t) // find out where
+					if i > -1 {
 
-				var newLine string
-				// check each word
-				for _, word := range strings.Fields(l) {
-
-					i := 0
-					for {
-						i = strings.Index(word[i:], t) // find out where
-
-						if i > -1 {
-
-							// if this isn't an exact match
-							if i > 0 && isAlphaNumeric(rune(word[i-1])) || i < len(word)-len(t) && isAlphaNumeric(rune(word[i+len(t)])) {
-								// replace the word with a capitolized version
-								word = strings.Replace(word, t, wordify(specificType, unicode.IsUpper(rune(strings.TrimLeft(word, "*&")[0]))), 1)
-							} else {
-								// replace the word as is
-								word = strings.Replace(word, t, specificType, 1)
-							}
-
+						// if this isn't an exact match
+						if i > 0 && isAlphaNumeric(rune(word[i-1])) || i < len(word)-len(t) && isAlphaNumeric(rune(word[i+len(t)])) {
+							// replace the word with a capitolized version
+							word = strings.Replace(word, t, wordify(specificType, unicode.IsUpper(rune(strings.TrimLeft(word, "*&")[0]))), 1)
 						} else {
-							newLine = newLine + word + space
-							break
+							// replace the word as is
+							word = strings.Replace(word, t, specificType, 1)
 						}
-
+					} else {
+						break
 					}
 				}
-				l = newLine
 			}
 		}
-
-		if comment != "" {
-			buf.WriteString(line(comment))
-			comment = ""
-		}
-
-		// is this line a comment?
-		// TODO: should we handle /* */ comments?
-		if strings.HasPrefix(l, "//") {
-			// record this line to print later
-			comment = l
-			continue
-		}
-
-		// write the line
-		buf.WriteString(line(l))
+		lineBuf.WriteString(word)
+	}
+	if lineBuf.Len() > 0 {
+		buf.Write(lineBuf.Bytes())
 	}
 
 	// write it out


### PR DESCRIPTION
The problem is complex types like maps are not correctly generated. 

For demonstration create sample input for a generated struct with a corresponding  map of that struct:
```
$ cat <<EOM > input
package main
import "github.com/cheekybits/genny/generic"

type MyType generic.Type

type MyTypeThing struct {
    thing MyType
}
type MapMyType map[string]MyTypeThing
EOM
```

Then pass the file through genny:
```
$ cat input | genny gen MyType=string
// This file was automatically generated by genny.
// Any changes will be lost if this file is regenerated.
// see https://github.com/cheekybits/genny

package main

type StringThing struct {
        thing string
}
type MapString map[string]stringThing
```

Note the generated map type is `map[string]stringThing` with incorrect capitalization on `stringThing`.  The reason for this is that the current code treats the `map[string]stringThing` as a single token and it thinks `stringThing` should be lower case because `map` is lower case.

This PR tweaks how `genny` tokenizes the input, using the `text/scanner` codebase which is designed to parse `go` code.  The changes simply tokenize everything looking only for identifiers.  If it is not an identifier it goes into the output stream, otherwise it is processed to substitute in the generated type.  This will turn `map[string]MyTypeThing` into these tokens: `map`, `[`, `string`, `]`, `MyTypeThing` which are processed individually. Where only the `map`, `string` and `MyTypeThing` would be marked as identifiers.
